### PR TITLE
feat(etl): scaffold raw layer (http client, DB engine, raw ingestion)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,16 @@
+# secrets
 config/.env
+.env
+*.env
+
+# python
+__pycache__/
+*.py[cod]
+*.egg-info/
+
+# jupyter
+.ipynb_checkpoints/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/etl/__init__.py
+++ b/etl/__init__.py
@@ -1,0 +1,1 @@
+"""IPEDS ETL package."""

--- a/etl/http.py
+++ b/etl/http.py
@@ -1,0 +1,124 @@
+"""
+etl/http.py
+-----------
+This module handles all HTTP requests to the Urban Institute IPEDS API.
+
+It uses:
+- A persistent `requests.Session` for connection reuse.
+- Exponential backoff for retryable errors.
+- Respect for API rate limits (RPS delay).
+- Automatic pagination handling (using `next` from response).
+- Centralized config from `etl/config.py`.
+
+This is the ONLY place that should call the API directly.
+Other modules (e.g., raw_io.py) call `fetch_endpoint_data(...)`.
+"""
+
+from __future__ import annotations
+
+import time
+import requests
+from urllib.parse import urljoin
+from typing import Any
+
+from etl.config import settings
+
+# -----------------------------------------------------------------------------
+# Global session object to reuse TCP connections
+# -----------------------------------------------------------------------------
+# This avoids the overhead of reconnecting for every request.
+session = requests.Session()
+
+
+# -----------------------------------------------------------------------------
+# Retry logic with exponential backoff
+# -----------------------------------------------------------------------------
+def get_with_retries(
+    url: str,
+    params: dict[str, Any] | None = None,
+    max_retries: int = settings.MAX_RETRIES,
+) -> requests.Response:
+    """
+    Makes a GET request with retry logic and exponential backoff.
+    Used by the main data fetcher below.
+
+    Parameters
+    ----------
+    url : str
+        Full API URL (e.g., https://.../directory/).
+    params : dict, optional
+        Query string parameters (e.g., {"year": 2022, "page": 3}).
+    max_retries : int
+        Max number of retry attempts before raising an error.
+
+    Returns
+    -------
+    response : requests.Response
+        The successful response (status 200).
+
+    Raises
+    ------
+    Exception
+        If all retries fail.
+    """
+    for attempt in range(max_retries):
+        try:
+            response = session.get(
+                url,
+                params=params,
+                headers={"User-Agent": settings.USER_AGENT},
+                timeout=settings.REQUEST_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            return response
+
+        except requests.RequestException as e:
+            print(f"[WARN] Attempt {attempt + 1} failed for {url}: {e}")
+            time.sleep(2 ** attempt)  # Exponential backoff: 1s, 2s, 4s...
+
+    raise Exception(f"[FAIL] Giving up after {max_retries} failed attempts to fetch {url}")
+
+
+# -----------------------------------------------------------------------------
+# Main function: fetch all paginated results for one endpoint + year
+# -----------------------------------------------------------------------------
+def fetch_endpoint_data(endpoint_path: str, year: int) -> list[dict[str, Any]]:
+    """
+    Downloads all data from a paginated Urban IPEDS API endpoint for a given year.
+
+    `endpoint_path` can be either:
+      - "ipeds/directory/"            (we'll append "{year}/")
+      - "ipeds/directory/{year}/"     (we'll format it)
+    """
+    all_results: list[dict[str, Any]] = []
+
+    # Normalize base and path
+    base = settings.URBAN_BASE_URL.rstrip("/") + "/"
+    # Allow both "ipeds/directory/" and "ipeds/directory/{year}/"
+    if "{year}" in endpoint_path:
+        path = endpoint_path.format(year=year).strip("/") + "/"
+    else:
+        path = f"{endpoint_path.strip('/')}/{year}/"
+
+    # First page URL
+    url = urljoin(base, path)
+
+    while True:
+        # GET (no year in query; year is in path)
+        response = get_with_retries(url, params=None)
+        data = response.json()
+
+        # Collect records from this page
+        all_results.extend(data.get("results", []))
+
+        # Follow 'next' if present (it can be absolute or relative)
+        next_url = data.get("next")
+        if not next_url:
+            break
+        url = next_url if next_url.startswith("http") else urljoin(base, next_url.lstrip("/"))
+
+        # gentle rate limit
+        time.sleep(1.0 / settings.RATE_LIMIT_RPS)
+
+    print(f"[OK] Fetched {len(all_results):,} records from {path} (year={year})")
+    return all_results

--- a/etl/raw_io.py
+++ b/etl/raw_io.py
@@ -1,0 +1,145 @@
+"""
+etl/raw_io.py
+-------------
+Handles raw data ingestion into ipeds_raw.{endpoint}_raw tables.
+
+This layer stores the exact JSON payloads returned from the Urban Institute API,
+plus metadata about the source (URL, page, hash, etc.) for auditing and reproducibility.
+
+Each row represents one page of results, not individual records.
+
+Table schema (per endpoint) looks like:
+
+    ipeds_raw.directory_raw
+    ------------------------
+    - year         INTEGER
+    - page_number  INTEGER
+    - source_url   TEXT
+    - source_hash  TEXT        -- MD5 or SHA1 hash of the payload
+    - ingested_at  TIMESTAMP   -- when this record was inserted
+    - payload      JSONB       -- the exact API response
+
+This is append-only by default.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
+from typing import Any
+
+from etl.config import settings
+from etl.db import get_sqlalchemy_engine
+from etl.http import fetch_endpoint_data
+
+# -----------------------------------------------------------------------------
+# Create raw table for an endpoint (if not already created)
+# -----------------------------------------------------------------------------
+def ensure_raw_table(endpoint: str) -> None:
+    """
+    Creates a raw table if it doesn't exist, with the standard structure.
+
+    Table will be named: ipeds_raw.{endpoint}_raw
+
+    Parameters
+    ----------
+    endpoint : str
+        The IPEDS dataset (e.g., "directory", "admissions").
+
+    Returns
+    -------
+    None
+    """
+    sql = f"""
+    CREATE TABLE IF NOT EXISTS ipeds_raw.{endpoint}_raw (
+        year INTEGER NOT NULL,
+        page_number INTEGER NOT NULL,
+        source_url TEXT NOT NULL,
+        source_hash TEXT NOT NULL,
+        ingested_at TIMESTAMP NOT NULL DEFAULT NOW(),
+        payload JSONB NOT NULL
+    );
+    """
+
+    engine = get_sqlalchemy_engine(echo=settings.LOG_SQL)
+    with engine.begin() as conn:
+        conn.execute(text(sql))
+
+
+# -----------------------------------------------------------------------------
+# Insert raw page payloads + metadata into the raw table
+# -----------------------------------------------------------------------------
+def insert_raw_payloads(endpoint: str, year: int, endpoint_path: str) -> None:
+    """
+    Pulls API results for a given endpoint/year and inserts them into ipeds_raw.
+
+    Each page of results is saved as one row in the raw table.
+
+    Parameters
+    ----------
+    endpoint : str
+        Short name like "directory".
+    year : int
+        Target year to fetch.
+    endpoint_path : str
+        API path fragment like "/directory/".
+
+    Returns
+    -------
+    None
+    """
+    ensure_raw_table(endpoint)
+
+    engine = get_sqlalchemy_engine(echo=settings.LOG_SQL)
+
+    # Get all paginated results (flattened list of records)
+    all_records = fetch_endpoint_data(endpoint_path, year)
+
+    # We simulate pagination here to store 1 row per "page" in the raw table
+    # even though fetch_endpoint_data returned everything flattened.
+    # If you want to store 1 row per *record*, modify this logic.
+    page_size = 500  # arbitrary, for splitting into chunks
+    chunks = [all_records[i:i + page_size] for i in range(0, len(all_records), page_size)]
+
+    with engine.begin() as conn:
+        for page_number, chunk in enumerate(chunks, start=1):
+            payload_json = json.dumps(chunk, sort_keys=True)
+
+            source_url = f"{settings.URBAN_BASE_URL.rstrip('/')}{endpoint_path}?year={year}&page={page_number}"
+            source_hash = hashlib.sha1(payload_json.encode("utf-8")).hexdigest()
+
+            insert_sql = text(f"""
+                INSERT INTO ipeds_raw.{endpoint}_raw (
+                    year,
+                    page_number,
+                    source_url,
+                    source_hash,
+                    ingested_at,
+                    payload
+                )
+                VALUES (
+                    :year,
+                    :page_number,
+                    :source_url,
+                    :source_hash,
+                    :ingested_at,
+                    :payload
+                )
+            """)
+
+            conn.execute(
+                insert_sql,
+                {
+                    "year": year,
+                    "page_number": page_number,
+                    "source_url": source_url,
+                    "source_hash": source_hash,
+                    "ingested_at": datetime.utcnow(),
+                    "payload": payload_json,
+                }
+            )
+
+    print(f"[OK] Inserted {len(chunks)} page(s) into ipeds_raw.{endpoint}_raw for year {year}")

--- a/notebooks/10_load_raw_test.ipynb
+++ b/notebooks/10_load_raw_test.ipynb
@@ -1,0 +1,260 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "705b08d0-f220-4bda-8ef1-4fab491bc3d1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✔ project root: C:\\Users\\keith\\Documents\\ipeds_etl\\ipeds_etl\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "WindowsPath('C:/Users/keith/Documents/ipeds_etl/ipeds_etl')"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import sys, os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "def add_project_root():\n",
+    "    cwd = Path.cwd()\n",
+    "    for p in (cwd, *cwd.parents):\n",
+    "        if (p / \"etl\").is_dir() and (p / \"sql\").exists():\n",
+    "            if str(p) not in sys.path:\n",
+    "                sys.path.insert(0, str(p))\n",
+    "            print(\"✔ project root:\", p)\n",
+    "            return p\n",
+    "    raise RuntimeError(\"Could not find project root with 'etl' and 'sql'.\")\n",
+    "\n",
+    "add_project_root()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4b58b01c-0cc1-46a4-888a-9ad9529af893",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DB URL: postgresql+psycopg2://ipeds_loader:***@localhost:5432/ipeds_db\n",
+      "Ping: ('ipeds_db', 'ipeds_loader')\n",
+      "Schemas: ['ipeds_core', 'ipeds_dim', 'ipeds_raw', 'ipeds_vw', 'public']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sqlalchemy.engine import make_url\n",
+    "from etl.config import settings, dump_settings\n",
+    "from etl.db import ping, list_ipeds_schemas\n",
+    "\n",
+    "print(\"DB URL:\", make_url(settings.DATABASE_URL).render_as_string(hide_password=True))\n",
+    "print(\"Ping:\", ping())                  # expect ('ipeds_db', 'ipeds_loader')\n",
+    "print(\"Schemas:\", list_ipeds_schemas()) # expect ipeds_raw/core/dim/vw + public"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "611e8a93-93c4-460b-a80e-4547d2123532",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BASE: https://educationdata.urban.org/api/v1/college-university/\n",
+      "[OK] Fetched 6,256 records from ipeds/directory/2022/ (year=2022)\n",
+      "[OK] Inserted 13 page(s) into ipeds_raw.directory_raw for year 2022\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1) (You already ran add_project_root)\n",
+    "from etl.config import settings\n",
+    "print(\"BASE:\", settings.URBAN_BASE_URL)\n",
+    "# 2) If you JUST edited http.py, reload it (safe to run either way)\n",
+    "from importlib import reload\n",
+    "import etl.http as http\n",
+    "reload(http)\n",
+    "\n",
+    "from etl.raw_io import insert_raw_payloads\n",
+    "insert_raw_payloads(\"directory\", 2022, \"ipeds/directory/\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "7c37b041-353c-405b-bd8f-df7457a9f7ce",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>unitid</th>\n",
+       "      <th>inst_name</th>\n",
+       "      <th>city</th>\n",
+       "      <th>state_abbr</th>\n",
+       "      <th>sector</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>100654</td>\n",
+       "      <td>Alabama A &amp; M University</td>\n",
+       "      <td>Normal</td>\n",
+       "      <td>AL</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>100663</td>\n",
+       "      <td>University of Alabama at Birmingham</td>\n",
+       "      <td>Birmingham</td>\n",
+       "      <td>AL</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>100690</td>\n",
+       "      <td>Amridge University</td>\n",
+       "      <td>Montgomery</td>\n",
+       "      <td>AL</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>100706</td>\n",
+       "      <td>University of Alabama in Huntsville</td>\n",
+       "      <td>Huntsville</td>\n",
+       "      <td>AL</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>100724</td>\n",
+       "      <td>Alabama State University</td>\n",
+       "      <td>Montgomery</td>\n",
+       "      <td>AL</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   unitid                            inst_name        city state_abbr  sector\n",
+       "0  100654             Alabama A & M University      Normal         AL       1\n",
+       "1  100663  University of Alabama at Birmingham  Birmingham         AL       1\n",
+       "2  100690                   Amridge University  Montgomery         AL       2\n",
+       "3  100706  University of Alabama in Huntsville  Huntsville         AL       1\n",
+       "4  100724             Alabama State University  Montgomery         AL       1"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sqlalchemy import text\n",
+    "from etl.db import get_sqlalchemy_engine\n",
+    "import pandas as pd\n",
+    "\n",
+    "eng = get_sqlalchemy_engine()\n",
+    "\n",
+    "# page-level counts\n",
+    "df_pages = pd.read_sql(\n",
+    "    text(\"\"\"\n",
+    "      SELECT page_number, jsonb_array_length(payload) AS records_in_chunk, ingested_at\n",
+    "      FROM ipeds_raw.directory_raw\n",
+    "      WHERE year = :y\n",
+    "      ORDER BY page_number\n",
+    "    \"\"\"),\n",
+    "    eng, params={\"y\": 2022}\n",
+    ")\n",
+    "df_pages.head()\n",
+    "\n",
+    "# flattened preview\n",
+    "df_flat = pd.read_sql(\n",
+    "    text(\"\"\"\n",
+    "      SELECT\n",
+    "        (elem->>'unitid')::int AS unitid,\n",
+    "        elem->>'inst_name'     AS inst_name,\n",
+    "        elem->>'city'          AS city,\n",
+    "        elem->>'state_abbr'    AS state_abbr,\n",
+    "        (elem->>'sector')::int AS sector\n",
+    "      FROM ipeds_raw.directory_raw r\n",
+    "      CROSS JOIN LATERAL jsonb_array_elements(r.payload) AS elem\n",
+    "      WHERE r.year = :y\n",
+    "      LIMIT 200\n",
+    "    \"\"\"),\n",
+    "    eng, params={\"y\": 2022}\n",
+    ")\n",
+    "df_flat.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a9aebd9-f681-4123-9db2-aab6f3712705",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
- Add http.py with retries, rate limit, and robust URL joining
- Add db.py engine helper + ping/list schemas + get_sqlalchemy_engine()
- Add raw_io.py to create ipeds_raw tables and write JSON + metadata
- Add __init__.py so etl is a package
- Add .gitignore (env, __pycache__, checkpoints)
- Add 10_load_raw_test.ipynb notebook to demo Directory 2022 load

Notes:
- Leaves config/.env out of git
- Verified Directory 2022 loads into ipeds_raw.directory_raw