### PR TITLE
feat(core): add IPEDS Directory core table, registry, and loader

### DIFF
--- a/etl/core_io.py
+++ b/etl/core_io.py
@@ -1,0 +1,164 @@
+"""
+etl/core_io.py
+--------------
+Loads clean, typed rows into ipeds_core.{endpoint} from ipeds_raw.{endpoint}_raw.
+
+Design:
+- Table DDL comes from etl/registry.py (authoritative column list + PK).
+- Row shaping comes from the endpoint's mapper (e.g., etl.mappers.directory.map_directory_row).
+- Idempotent UPSERT on the declared primary key.
+"""
+
+from __future__ import annotations
+from typing import Iterable, List, Dict, Any, Optional
+
+import json
+from sqlalchemy import text
+
+from etl.db import get_sqlalchemy_engine
+from etl.registry import get_endpoint_config
+# mappers are referenced via the registry; we don't import a specific mapper here
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+def _ensure_core_table(endpoint: str) -> None:
+    """
+    Create ipeds_core.{endpoint} if missing, using registry schema & PK.
+
+    The registry provides:
+      - schema: {column_name: sql_type, ...}
+      - primary_key: ["col1", "col2"]
+    """
+    cfg = get_endpoint_config(endpoint)
+    cols = cfg["schema"]
+    pk = cfg["primary_key"]
+    table = f"ipeds_core.{endpoint}"
+
+    # 1) Build column DDL like: "unitid INTEGER NOT NULL, year INTEGER NOT NULL, inst_name TEXT, ..."
+    col_defs = ",\n    ".join([f"{name} {sqltype}" for name, sqltype in cols.items()])
+    pk_clause = f",\n    PRIMARY KEY ({', '.join(pk)})" if pk else ""
+
+    ddl = f"""
+    CREATE SCHEMA IF NOT EXISTS ipeds_core;
+
+    CREATE TABLE IF NOT EXISTS {table} (
+        {col_defs}
+        {pk_clause}
+    );
+    """
+
+    engine = get_sqlalchemy_engine()
+    with engine.begin() as cx:
+        cx.execute(text(ddl))
+
+
+def _iter_raw_records(endpoint: str, years: Optional[Iterable[int]] = None) -> Iterable[Dict[str, Any]]:
+    """
+    Yield individual JSON records from ipeds_raw.{endpoint}_raw for the given years.
+
+    Notes:
+    - Each raw row is one "page" (payload JSON array). We expand it into per-record dicts.
+    - Handles payload stored as JSONB (already a Python list) or TEXT (string -> json.loads).
+    """
+    table = f"ipeds_raw.{endpoint}_raw"
+    engine = get_sqlalchemy_engine()
+
+    if years:
+        placeholders = ", ".join([str(int(y)) for y in years])
+        sql = f"SELECT year, page_number, payload FROM {table} WHERE year IN ({placeholders}) ORDER BY year, page_number"
+    else:
+        sql = f"SELECT year, page_number, payload FROM {table} ORDER BY year, page_number"
+
+    with engine.connect() as cx:
+        for yr, page, payload in cx.execute(text(sql)):
+            # payload could be a Python list (JSONB) or a JSON string
+            if isinstance(payload, str):
+                page_items = json.loads(payload)
+            else:
+                page_items = payload
+
+            if not isinstance(page_items, list):
+                # Be defensive: the API should have returned a list of objects.
+                continue
+
+            for obj in page_items:
+                # Attach the 'year' from the raw row as a guard (some payloads omit it).
+                if "year" not in obj:
+                    obj["year"] = yr
+                yield obj
+
+
+def _build_upsert_sql(endpoint: str) -> str:
+    """
+    Build parameterized INSERT ... ON CONFLICT DO UPDATE statement from registry.
+    """
+    cfg = get_endpoint_config(endpoint)
+    cols = list(cfg["schema"].keys())            # insertion order follows registry schema
+    pk = cfg["primary_key"]
+    non_pk_cols = [c for c in cols if c not in pk]
+
+    col_list = ", ".join(cols)
+    param_list = ", ".join([f":{c}" for c in cols])
+    conflict_cols = ", ".join(pk)
+    set_list = ", ".join([f"{c} = EXCLUDED.{c}" for c in non_pk_cols])
+
+    sql = f"""
+    INSERT INTO ipeds_core.{endpoint} ({col_list})
+    VALUES ({param_list})
+    ON CONFLICT ({conflict_cols}) DO UPDATE
+    SET {set_list};
+    """
+    return sql
+
+
+# -----------------------------------------------------------------------------
+# Public API
+# -----------------------------------------------------------------------------
+def load_core_from_raw(endpoint: str, years: Optional[Iterable[int]] = None, batch_size: int = 1000) -> int:
+    """
+    Read ipeds_raw.{endpoint}_raw, map/clean records, and UPSERT into ipeds_core.{endpoint}.
+
+    Parameters
+    ----------
+    endpoint : str
+        e.g., "directory"
+    years : Optional[Iterable[int]]
+        If provided, restrict to these years; otherwise load all years present in raw.
+    batch_size : int
+        How many mapped rows to send per execute() call.
+
+    Returns
+    -------
+    int : number of records processed (mapped rows, not pages)
+    """
+    cfg = get_endpoint_config(endpoint)
+    mapper = cfg["mapper"]
+
+    _ensure_core_table(endpoint)
+    upsert_sql = text(_build_upsert_sql(endpoint))
+
+    engine = get_sqlalchemy_engine()
+    rows_buffer: List[Dict[str, Any]] = []
+    processed = 0
+
+    def flush():
+        nonlocal rows_buffer, processed
+        if not rows_buffer:
+            return
+        with engine.begin() as cx:
+            cx.execute(upsert_sql, rows_buffer)
+        processed += len(rows_buffer)
+        rows_buffer = []
+
+    # Iterate raw records and map them into core-shaped dicts
+    for raw in _iter_raw_records(endpoint, years=years):
+        mapped = mapper(raw)  # returns dict with keys matching registry schema
+        rows_buffer.append(mapped)
+        if len(rows_buffer) >= batch_size:
+            flush()
+
+    flush()  # final partial batch
+    print(f"[OK] Upserted {processed} record(s) into ipeds_core.{endpoint}")
+    return processed

--- a/etl/mappers/directory.py
+++ b/etl/mappers/directory.py
@@ -1,0 +1,238 @@
+"""
+etl/mappers/directory.py
+------------------------
+Mapper for the IPEDS *Directory* endpoint.
+
+Goal
+----
+Turn ONE raw JSON record (a Python `dict`) into a clean, typed `dict` whose keys
+exactly match the columns declared in `etl/registry.py` for the "directory" endpoint.
+
+Key behaviors
+-------------
+- IPEDS special values (-1, -2, -3) and blank strings are treated as *missing* (-> None).
+- Gentle casting:
+    _to_int   -> returns int or None
+    _to_float -> returns float or None
+    _to_str   -> returns trimmed string or None
+- Field-name resilience: `_pick()` can look up from a list of candidate keys to
+  tolerate historical variations (e.g., "inst_name" vs "instnm").
+"""
+
+from __future__ import annotations
+from typing import Any, Dict, Optional
+
+
+# -----------------------------------------------------------------------------
+# Helpers: missing-value detection, key selection, and safe casting
+# -----------------------------------------------------------------------------
+
+def _is_missing(v: Any) -> bool:
+    """
+    Return True if `v` should be considered "missing" in IPEDS land.
+
+    Handles both numeric and string encodings of special codes:
+      - -1 = Missing/not reported
+      - -2 = Not applicable
+      - -3 = Suppressed data
+    Also treats None and empty/whitespace-only strings as missing.
+    """
+    # Explicit None => missing
+    if v is None:
+        return True
+
+    # Strings: trim whitespace and check for empty or stringified special codes
+    if isinstance(v, str):
+        s = v.strip()
+        if s == "" or s in {"-1", "-2", "-3"}:
+            return True
+        return False
+
+    # Non-strings: check the numeric special codes
+    return v in (-1, -2, -3)
+
+
+def _pick(row: Dict[str, Any], keys: list[str]) -> Optional[Any]:
+    """
+    Return the first non-missing value from `row` among the provided `keys`.
+
+    Why:
+    - Payloads sometimes vary in field names across years/feeds.
+    - This lets us declare a preference order, e.g.:
+        _pick(row, ["inst_name", "institution_name", "instnm"])
+    """
+    for k in keys:
+        if k in row and not _is_missing(row[k]):
+            return row[k]
+    return None
+
+
+def _to_int(v: Any) -> Optional[int]:
+    """
+    Cast to int, returning None if the value is missing or malformed.
+
+    Accepts:
+      - int (returned as-is),
+      - strings like "42" (whitespace tolerated),
+      - otherwise returns None.
+    """
+    if _is_missing(v):
+        return None
+    try:
+        if isinstance(v, str):
+            v = v.strip()
+        return int(v)
+    except (ValueError, TypeError):
+        return None
+
+
+def _to_float(v: Any) -> Optional[float]:
+    """
+    Cast to float, returning None if missing or malformed.
+
+    Accepts:
+      - float/int,
+      - strings like "12.34" (whitespace tolerated),
+      - otherwise returns None.
+    """
+    if _is_missing(v):
+        return None
+    try:
+        if isinstance(v, str):
+            v = v.strip()
+        return float(v)
+    except (ValueError, TypeError):
+        return None
+
+
+def _to_str(v: Any) -> Optional[str]:
+    """
+    Cast to a trimmed string, returning None if missing or empty after trim.
+
+    Notes:
+      - Preserves meaningful text (e.g., URLs, names).
+      - Converts numbers to strings only when they aren't IPEDS-missing codes.
+    """
+    if _is_missing(v):
+        return None
+    s = str(v).strip()
+    return s if s else None
+
+
+# -----------------------------------------------------------------------------
+# Main mapper: raw JSON record -> typed dict aligned to registry schema
+# -----------------------------------------------------------------------------
+
+def map_directory_row(row: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Normalize one *Directory* record.
+    Returns a dict whose keys exactly match the columns declared for
+    `ipeds_core.directory` in `etl/registry.py`.
+    """
+    return {
+        # --------------------------- PRIMARY KEY ----------------------------
+        "unitid": _to_int(_pick(row, ["unitid"])),
+        "year": _to_int(_pick(row, ["year"])),
+
+        # ----------------------- Identity / contact -------------------------
+        "opeid": _to_str(_pick(row, ["opeid"])),
+        "inst_name": _to_str(_pick(row, ["inst_name", "institution_name", "instnm", "name"])),
+        "inst_alias": _to_str(_pick(row, ["inst_alias"])),
+        "address": _to_str(_pick(row, ["address"])),
+        "city": _to_str(_pick(row, ["city"])),
+        "state_abbr": _to_str(_pick(row, ["state_abbr", "stabbr", "state"])),
+        "zip": _to_str(_pick(row, ["zip", "zip5", "zip_code"])),
+        "phone_number": _to_str(_pick(row, ["phone_number", "phone"])),
+        "url_school": _to_str(_pick(row, ["url_school", "website", "web_address"])),
+        "url_fin_aid": _to_str(_pick(row, ["url_fin_aid"])),
+        "url_application": _to_str(_pick(row, ["url_application"])),
+        "url_netprice": _to_str(_pick(row, ["url_netprice"])),
+        "url_veterans": _to_str(_pick(row, ["url_veterans"])),
+        "url_athletes": _to_str(_pick(row, ["url_athletes"])),
+        "url_disability_services": _to_str(_pick(row, ["url_disability_services"])),
+        "ein": _to_str(_pick(row, ["ein"])),
+        "duns": _to_str(_pick(row, ["duns"])),
+        "ueis": _to_str(_pick(row, ["ueis"])),
+        "chief_admin_name": _to_str(_pick(row, ["chief_admin_name"])),
+        "chief_admin_title": _to_str(_pick(row, ["chief_admin_title"])),
+        "inst_system_name": _to_str(_pick(row, ["inst_system_name"])),
+
+        # ---------------------------- Geography -----------------------------
+        "fips": _to_int(_pick(row, ["fips"])),
+        "county_name": _to_str(_pick(row, ["county_name"])),
+        "county_fips": _to_int(_pick(row, ["county_fips"])),
+        "region": _to_int(_pick(row, ["region"])),
+        "urban_centric_locale": _to_int(_pick(row, ["urban_centric_locale", "locale"])),
+        "cbsa": _to_int(_pick(row, ["cbsa"])),
+        "cbsa_type": _to_int(_pick(row, ["cbsa_type"])),
+        "csa": _to_int(_pick(row, ["csa"])),
+        "necta": _to_int(_pick(row, ["necta"])),
+        "congress_district_id": _to_int(_pick(row, ["congress_district_id"])),
+        "latitude": _to_float(_pick(row, ["latitude", "lat"])),
+        "longitude": _to_float(_pick(row, ["longitude", "lon", "lng"])),
+
+        # ------------------------ Status / attributes -----------------------
+        "inst_status": _to_int(_pick(row, ["inst_status"])),
+        "sector": _to_int(_pick(row, ["sector", "sector_cd"])),
+        "inst_control": _to_int(_pick(row, ["inst_control", "control"])),
+        "institution_level": _to_int(_pick(row, ["institution_level", "level", "iclevel"])),
+        "inst_category": _to_int(_pick(row, ["inst_category"])),
+        "inst_size": _to_int(_pick(row, ["inst_size"])),
+        "degree_granting": _to_int(_pick(row, ["degree_granting"])),
+        "title_iv_indicator": _to_int(_pick(row, ["title_iv_indicator"])),
+        "hbcu": _to_int(_pick(row, ["hbcu"])),
+        "tribal_college": _to_int(_pick(row, ["tribal_college"])),
+        "land_grant": _to_int(_pick(row, ["land_grant"])),
+        "hospital": _to_int(_pick(row, ["hospital"])),
+        "medical_degree": _to_int(_pick(row, ["medical_degree"])),
+        "open_public": _to_int(_pick(row, ["open_public"])),
+        "currently_active_ipeds": _to_int(_pick(row, ["currently_active_ipeds"])),
+        "postsec_public_active": _to_int(_pick(row, ["postsec_public_active"])),
+        "postsec_public_active_title_iv": _to_int(_pick(row, ["postsec_public_active_title_iv"])),
+        "primarily_postsecondary": _to_int(_pick(row, ["primarily_postsecondary"])),
+        "offering_highest_degree": _to_int(_pick(row, ["offering_highest_degree"])),
+        "offering_highest_level": _to_int(_pick(row, ["offering_highest_level"])),
+        "offering_undergrad": _to_int(_pick(row, ["offering_undergrad"])),
+        "offering_grad": _to_int(_pick(row, ["offering_grad"])),
+        "reporting_method": _to_int(_pick(row, ["reporting_method"])),
+        "inst_system_flag": _to_int(_pick(row, ["inst_system_flag"])),
+        "comparison_group": _to_int(_pick(row, ["comparison_group"])),
+        "comparison_group_custom": _to_int(_pick(row, ["comparison_group_custom"])),
+
+        # --------------------- Mergers / deletions / dates -------------------
+        "newid": _to_int(_pick(row, ["newid"])),
+        "date_closed": _to_str(_pick(row, ["date_closed"])),
+        "year_deleted": _to_int(_pick(row, ["year_deleted"])),
+
+        # ---------------------- Carnegie classifications ---------------------
+        "cc_basic_2000": _to_int(_pick(row, ["cc_basic_2000"])),
+        "cc_basic_2010": _to_int(_pick(row, ["cc_basic_2010"])),
+        "cc_basic_2015": _to_int(_pick(row, ["cc_basic_2015"])),
+        "cc_basic_2018": _to_int(_pick(row, ["cc_basic_2018"])),
+        "cc_basic_2021": _to_int(_pick(row, ["cc_basic_2021"])),
+
+        "cc_instruc_undergrad_2010": _to_int(_pick(row, ["cc_instruc_undergrad_2010"])),
+        "cc_instruc_undergrad_2015": _to_int(_pick(row, ["cc_instruc_undergrad_2015"])),
+        "cc_instruc_undergrad_2018": _to_int(_pick(row, ["cc_instruc_undergrad_2018"])),
+        "cc_instruc_undergrad_2021": _to_int(_pick(row, ["cc_instruc_undergrad_2021"])),
+
+        "cc_instruc_grad_2010": _to_int(_pick(row, ["cc_instruc_grad_2010"])),
+        "cc_instruc_grad_2015": _to_int(_pick(row, ["cc_instruc_grad_2015"])),
+        "cc_instruc_grad_2018": _to_int(_pick(row, ["cc_instruc_grad_2018"])),
+        "cc_instruc_grad_2021": _to_int(_pick(row, ["cc_instruc_grad_2021"])),
+
+        "cc_undergrad_2010": _to_int(_pick(row, ["cc_undergrad_2010"])),
+        "cc_undergrad_2015": _to_int(_pick(row, ["cc_undergrad_2015"])),
+        "cc_undergrad_2018": _to_int(_pick(row, ["cc_undergrad_2018"])),
+        "cc_undergrad_2021": _to_int(_pick(row, ["cc_undergrad_2021"])),
+
+        "cc_enroll_2010": _to_int(_pick(row, ["cc_enroll_2010"])),
+        "cc_enroll_2015": _to_int(_pick(row, ["cc_enroll_2015"])),
+        "cc_enroll_2018": _to_int(_pick(row, ["cc_enroll_2018"])),
+        "cc_enroll_2021": _to_int(_pick(row, ["cc_enroll_2021"])),
+
+        "cc_size_setting_2010": _to_int(_pick(row, ["cc_size_setting_2010"])),
+        "cc_size_setting_2015": _to_int(_pick(row, ["cc_size_setting_2015"])),
+        "cc_size_setting_2018": _to_int(_pick(row, ["cc_size_setting_2018"])),
+        "cc_size_setting_2021": _to_int(_pick(row, ["cc_size_setting_2021"])),
+    }

--- a/etl/registry.py
+++ b/etl/registry.py
@@ -1,0 +1,192 @@
+"""
+etl/registry.py
+---------------
+A tiny in-code *catalog* (single source of truth) describing each endpoint the
+ETL knows about. The registry itself does not execute any SQL; instead:
+
+- `core_io._ensure_core_table()` reads `schema` and `primary_key` here to build
+  the `CREATE TABLE IF NOT EXISTS ipeds_core.{endpoint}` DDL (so yes—this is
+  where column definitions ultimately come from).
+- `core_io.load_core_from_raw()` looks up the endpoint’s `mapper` here to turn
+  raw JSON records into typed dicts that match the schema.
+- The optional `path` is the API path template (handy for reference/reuse).
+
+Add new endpoints by inserting another entry alongside "directory" with:
+  - path        : string template (usually ".../{year}/")
+  - schema      : { column_name: "SQL TYPE" }
+  - primary_key : list[str] used for UPSERT conflict target
+  - mapper      : callable(raw_record) -> dict aligned to `schema`
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+from etl.mappers.directory import map_directory_row  # raw JSON -> typed row
+
+
+# Type alias for clarity when reading code elsewhere. Each endpoint config is
+# a small dict with "path", "schema", "primary_key", and "mapper" keys.
+EndpointCfg = Dict[str, Any]
+
+
+# -----------------------------------------------------------------------------
+# Registry of endpoints
+# -----------------------------------------------------------------------------
+# Keys of REGISTRY are short endpoint names used throughout the project
+# (e.g., "directory", "admissions", "completions"). Values are configs.
+REGISTRY: Dict[str, EndpointCfg] = {
+    "directory": {
+        # API path template (year is a path segment for Urban’s IPEDS endpoints).
+        # We keep this here even if the current loader pulls from ipeds_raw only;
+        # it’s useful for documentation and future runners that call the API.
+        "path": "ipeds/directory/{year}/",
+
+        # Core table layout for ipeds_core.directory.
+        # IMPORTANT:
+        # - Column names here are the contract for the mapper output.
+        # - SQL types are Postgres types (TEXT, INTEGER, DOUBLE PRECISION, ...).
+        # - To add a new column later: add it here AND map it in the mapper.
+        "schema": {
+            # --- PRIMARY KEY (one row per institution-year) -------------------
+            "unitid": "INTEGER NOT NULL",
+            "year": "INTEGER NOT NULL",
+
+            # --- Identity / contact info -------------------------------------
+            "opeid": "TEXT",
+            "inst_name": "TEXT",
+            "inst_alias": "TEXT",
+            "address": "TEXT",
+            "city": "TEXT",
+            "state_abbr": "TEXT",
+            "zip": "TEXT",
+            "phone_number": "TEXT",
+            "url_school": "TEXT",
+            "url_fin_aid": "TEXT",
+            "url_application": "TEXT",
+            "url_netprice": "TEXT",
+            "url_veterans": "TEXT",
+            "url_athletes": "TEXT",
+            "url_disability_services": "TEXT",
+            "ein": "TEXT",
+            "duns": "TEXT",
+            "ueis": "TEXT",
+            "chief_admin_name": "TEXT",
+            "chief_admin_title": "TEXT",
+            "inst_system_name": "TEXT",
+
+            # --- Geography ----------------------------------------------------
+            "fips": "INTEGER",
+            "county_name": "TEXT",
+            "county_fips": "INTEGER",
+            "region": "INTEGER",
+            "urban_centric_locale": "INTEGER",
+            "cbsa": "INTEGER",
+            "cbsa_type": "INTEGER",
+            "csa": "INTEGER",
+            "necta": "INTEGER",
+            "congress_district_id": "INTEGER",
+            "latitude": "DOUBLE PRECISION",
+            "longitude": "DOUBLE PRECISION",
+
+            # --- Status / attributes -----------------------------------------
+            "inst_status": "INTEGER",
+            "sector": "INTEGER",
+            "inst_control": "INTEGER",
+            "institution_level": "INTEGER",
+            "inst_category": "INTEGER",
+            "inst_size": "INTEGER",
+            "degree_granting": "INTEGER",
+            "title_iv_indicator": "INTEGER",
+            "hbcu": "INTEGER",
+            "tribal_college": "INTEGER",
+            "land_grant": "INTEGER",
+            "hospital": "INTEGER",
+            "medical_degree": "INTEGER",
+            "open_public": "INTEGER",
+            "currently_active_ipeds": "INTEGER",
+            "postsec_public_active": "INTEGER",
+            "postsec_public_active_title_iv": "INTEGER",
+            "primarily_postsecondary": "INTEGER",
+            "offering_highest_degree": "INTEGER",
+            "offering_highest_level": "INTEGER",
+            "offering_undergrad": "INTEGER",
+            "offering_grad": "INTEGER",
+            "reporting_method": "INTEGER",
+            "inst_system_flag": "INTEGER",
+            "comparison_group": "INTEGER",
+            "comparison_group_custom": "INTEGER",
+
+            # --- Mergers / deletions / dates ---------------------------------
+            # `date_closed` often appears as text; we keep TEXT for simplicity.
+            "newid": "INTEGER",
+            "date_closed": "TEXT",
+            "year_deleted": "INTEGER",
+
+            # --- Carnegie classifications ------------------------------------
+            "cc_basic_2000": "INTEGER",
+            "cc_basic_2010": "INTEGER",
+            "cc_basic_2015": "INTEGER",
+            "cc_basic_2018": "INTEGER",
+            "cc_basic_2021": "INTEGER",
+
+            "cc_instruc_undergrad_2010": "INTEGER",
+            "cc_instruc_undergrad_2015": "INTEGER",
+            "cc_instruc_undergrad_2018": "INTEGER",
+            "cc_instruc_undergrad_2021": "INTEGER",
+
+            "cc_instruc_grad_2010": "INTEGER",
+            "cc_instruc_grad_2015": "INTEGER",
+            "cc_instruc_grad_2018": "INTEGER",
+            "cc_instruc_grad_2021": "INTEGER",
+
+            "cc_undergrad_2010": "INTEGER",
+            "cc_undergrad_2015": "INTEGER",
+            "cc_undergrad_2018": "INTEGER",
+            "cc_undergrad_2021": "INTEGER",
+
+            "cc_enroll_2010": "INTEGER",
+            "cc_enroll_2015": "INTEGER",
+            "cc_enroll_2018": "INTEGER",
+            "cc_enroll_2021": "INTEGER",
+
+            "cc_size_setting_2010": "INTEGER",
+            "cc_size_setting_2015": "INTEGER",
+            "cc_size_setting_2018": "INTEGER",
+            "cc_size_setting_2021": "INTEGER",
+        },
+
+        # Composite PK used by `core_io` to build the ON CONFLICT target. This
+        # ensures idempotent loads: re-running the same data updates the row
+        # instead of inserting duplicates.
+        "primary_key": ["unitid", "year"],
+
+        # Function that converts a raw JSON record into a dict whose keys match
+        # exactly the columns declared above under "schema".
+        "mapper": map_directory_row,
+    }
+}
+
+
+def get_endpoint_config(endpoint: str) -> EndpointCfg:
+    """
+    Fetch one endpoint's config from REGISTRY.
+
+    Raises
+    ------
+    KeyError
+        If the endpoint name isn't present in REGISTRY.
+    """
+    if endpoint not in REGISTRY:
+        raise KeyError(f"Endpoint '{endpoint}' is not registered in etl/registry.py")
+    return REGISTRY[endpoint]
+
+
+def list_endpoints() -> list[str]:
+    """
+    Convenience helper for notebooks or diagnostics.
+    Example:
+        >>> from etl.registry import list_endpoints
+        >>> list_endpoints()
+        ['directory']
+    """
+    return sorted(REGISTRY.keys())

--- a/notebooks/20_load_core_directory.ipynb
+++ b/notebooks/20_load_core_directory.ipynb
@@ -1,0 +1,288 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "50ce9c0a-12b6-4567-b6b0-9c3617bd1487",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ project root: C:\\Users\\keith\\Documents\\ipeds_etl\\ipeds_etl\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "WindowsPath('C:/Users/keith/Documents/ipeds_etl/ipeds_etl')"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import sys, os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "def add_project_root() -> Path:\n",
+    "    \"\"\"\n",
+    "    Add the repo root (the folder that contains 'etl/' and 'sql/') to sys.path\n",
+    "    so `from etl... import ...` works no matter where the notebook lives.\n",
+    "    \"\"\"\n",
+    "    cwd = Path.cwd()\n",
+    "    for p in (cwd, *cwd.parents):\n",
+    "        if (p / \"etl\").is_dir() and (p / \"sql\").exists():\n",
+    "            if str(p) not in sys.path:\n",
+    "                sys.path.insert(0, str(p))\n",
+    "            print(\"✓ project root:\", p)\n",
+    "            return p\n",
+    "    raise RuntimeError(\"Could not find project root with 'etl' and 'sql'.\")\n",
+    "\n",
+    "add_project_root()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d6f82271-b66a-4b09-99b8-0625cd05c7cf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DB URL: postgresql+psycopg2://ipeds_loader:***@localhost:5432/ipeds_db\n",
+      "Ping: ('ipeds_db', 'ipeds_loader')\n",
+      "Schemas: ['ipeds_core', 'ipeds_dim', 'ipeds_raw', 'ipeds_vw', 'public']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sqlalchemy.engine import make_url\n",
+    "from etl.config import settings\n",
+    "from etl.db import ping, list_ipeds_schemas\n",
+    "\n",
+    "print(\"DB URL:\", make_url(settings.DATABASE_URL).render_as_string(hide_password=True))\n",
+    "print(\"Ping:\", ping())\n",
+    "print(\"Schemas:\", list_ipeds_schemas())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "04d087ca-22d0-454f-b664-e13f7860ff16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ENDPOINT = \"directory\"\n",
+    "YEARS = [2022]   # you can add more later, e.g. [2020, 2021, 2022, 2023]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1251f2fd-d30e-4591-8771-d737c82c16d6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ ensured core table ipeds_core.directory\n"
+     ]
+    }
+   ],
+   "source": [
+    "# -----------------------------\n",
+    "# Core table creation (DDL)\n",
+    "# -----------------------------\n",
+    "from sqlalchemy import text\n",
+    "from etl.db import get_sqlalchemy_engine\n",
+    "from etl.registry import get_endpoint_config\n",
+    "\n",
+    "def ensure_core_table(endpoint: str) -> None:\n",
+    "    \"\"\"\n",
+    "    Ensure a typed, de-duplicated *core* table exists for an endpoint.\n",
+    "\n",
+    "    What this creates:\n",
+    "    - A table named: ipeds_core.{endpoint}\n",
+    "    - Columns and SQL types come from etl/registry.py (single source of truth)\n",
+    "    - PRIMARY KEY (unitid, year) to prevent duplicates for a given year\n",
+    "    - A couple of helpful indexes used constantly by analysts/joins\n",
+    "\n",
+    "    Why this is in code (and not a .sql file):\n",
+    "    - Keeps schema definition close to the ETL mapping logic\n",
+    "    - Lets us evolve columns per endpoint in one place (the registry)\n",
+    "    - Safe to run repeatedly: all DDL uses IF NOT EXISTS (idempotent)\n",
+    "    \"\"\"\n",
+    "    # Pull endpoint definition (columns + types, mapper, etc.)\n",
+    "    cfg = get_endpoint_config(endpoint)\n",
+    "    table = f\"ipeds_core.{endpoint}\"\n",
+    "\n",
+    "    # Turn {\"unitid\": \"INTEGER NOT NULL\", ...} into \"unitid INTEGER NOT NULL, ...\"\n",
+    "    cols_sql = [f\"{col} {sqltype}\" for col, sqltype in cfg[\"schema\"].items()]\n",
+    "    cols_block = \",\\n        \".join(cols_sql)\n",
+    "\n",
+    "    # DDL notes:\n",
+    "    # - PRIMARY KEY matches our upsert conflict target later.\n",
+    "    # - year index: common filter (dashboards by year).\n",
+    "    # - state_abbr index: common filter/aggregation (slicing by state).\n",
+    "    ddl = f\"\"\"\n",
+    "    CREATE TABLE IF NOT EXISTS {table} (\n",
+    "        {cols_block},\n",
+    "        PRIMARY KEY (unitid, year)\n",
+    "    );\n",
+    "    CREATE INDEX IF NOT EXISTS {endpoint}_year_idx  ON {table} (year);\n",
+    "    CREATE INDEX IF NOT EXISTS {endpoint}_state_idx ON {table} (state_abbr);\n",
+    "    \"\"\"\n",
+    "\n",
+    "    eng = get_sqlalchemy_engine()\n",
+    "\n",
+    "    # Execute each DDL statement in a single transaction.\n",
+    "    # We split on ';' because we're issuing multiple statements (DDL + indexes).\n",
+    "    with eng.begin() as cx:\n",
+    "        for stmt in ddl.strip().split(\";\"):\n",
+    "            s = stmt.strip()\n",
+    "            if s:\n",
+    "                cx.execute(text(s))\n",
+    "\n",
+    "    print(f\"✓ ensured core table {table}\")\n",
+    "\n",
+    "\n",
+    "# Example: make sure the table exists for the current endpoint constant\n",
+    "ensure_core_table(ENDPOINT)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f2a90be4-d0d8-49e8-9738-ce4dba145247",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✓ directory: upserted 6256 rows for year 2022 into ipeds_core.directory\n",
+      "TOTAL rows processed: 6256\n"
+     ]
+    }
+   ],
+   "source": [
+    "# -----------------------------\n",
+    "# Raw → Core load (UPSERT)\n",
+    "# -----------------------------\n",
+    "from typing import List, Dict, Any\n",
+    "from sqlalchemy import text\n",
+    "from etl.db import get_sqlalchemy_engine\n",
+    "from etl.mappers.directory import map_directory_row\n",
+    "from etl.registry import get_endpoint_config\n",
+    "\n",
+    "def load_core_for_year(endpoint: str, year: int) -> int:\n",
+    "    \"\"\"\n",
+    "    Move one year's worth of data from ipeds_raw → ipeds_core for a given endpoint.\n",
+    "\n",
+    "    Pipeline steps (per year):\n",
+    "    1) Read raw JSONB pages, flatten them to individual JSON objects (1 per institution)\n",
+    "       using jsonb_array_elements + LATERAL.\n",
+    "    2) Map/clean each raw JSON dict with the endpoint-specific mapper (handles types,\n",
+    "       trims strings, converts magic -1/-2/-3 to NULL, etc.).\n",
+    "    3) UPSERT into ipeds_core.{endpoint} on (unitid, year), updating non-PK columns.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    int : number of rows written (length of the mapped list).\n",
+    "    \"\"\"\n",
+    "    cfg = get_endpoint_config(endpoint)\n",
+    "    table = f\"ipeds_core.{endpoint}\"\n",
+    "\n",
+    "    # Preserve a deterministic column order for the INSERT.\n",
+    "    # This must match what the mapper outputs.\n",
+    "    schema_cols: List[str] = list(cfg[\"schema\"].keys())\n",
+    "\n",
+    "    # --- 1) Flatten raw JSON payloads into row-wise JSON (one dict per record) ---\n",
+    "    # We read from ipeds_raw.{endpoint}_raw where each row is a *page* with a JSONB\n",
+    "    # array called payload. jsonb_array_elements() expands that array into \"elem\".\n",
+    "    # CROSS JOIN LATERAL is the idiomatic way to iterate JSON arrays in Postgres.\n",
+    "    eng = get_sqlalchemy_engine()\n",
+    "    flatten_sql = text(f\"\"\"\n",
+    "        SELECT elem::jsonb AS row\n",
+    "        FROM ipeds_raw.{endpoint}_raw r\n",
+    "        CROSS JOIN LATERAL jsonb_array_elements(r.payload) AS elem\n",
+    "        WHERE r.year = :y\n",
+    "        ORDER BY r.page_number\n",
+    "    \"\"\")\n",
+    "    with eng.connect() as cx:\n",
+    "        raw_rows: List[Dict[str, Any]] = [r[0] for r in cx.execute(flatten_sql, {\"y\": year}).fetchall()]\n",
+    "\n",
+    "    # --- 2) Map/clean raw dicts to our core schema ---\n",
+    "    # The mapper returns a dict with exactly the keys in schema_cols (plus NULLs as needed).\n",
+    "    # If you add fields to the registry, update the mapper to provide those keys.\n",
+    "    mapped: List[Dict[str, Any]] = [map_directory_row(d) for d in raw_rows]\n",
+    "\n",
+    "    # --- 3) Build an UPSERT that updates all non-PK columns when the row already exists ---\n",
+    "    # We exclude PK columns from the SET list (unitid, year) since those define the row.\n",
+    "    set_cols = [c for c in schema_cols if c not in (\"unitid\", \"year\")]\n",
+    "\n",
+    "    # VALUES uses named parameters like :inst_name; we feed a list[dict] to cx.execute().\n",
+    "    # ON CONFLICT target must match the table's PRIMARY KEY.\n",
+    "    # We do a full-field overwrite on conflict — this is fine because the mapper\n",
+    "    # always produces authoritative values for that (unitid, year).\n",
+    "    insert_sql = text(f\"\"\"\n",
+    "        INSERT INTO {table} ({\", \".join(schema_cols)})\n",
+    "        VALUES ({\", \".join(\":\"+c for c in schema_cols)})\n",
+    "        ON CONFLICT (unitid, year) DO UPDATE\n",
+    "        SET {\", \".join(f\"{c}=EXCLUDED.{c}\" for c in set_cols)}\n",
+    "    \"\"\")\n",
+    "\n",
+    "    # --- 4) Execute in a single transaction for atomicity & speed ---\n",
+    "    with eng.begin() as cx:\n",
+    "        # Passing the whole list allows SQLAlchemy to do an executemany() style insert.\n",
+    "        cx.execute(insert_sql, mapped)\n",
+    "\n",
+    "    print(f\"✓ {endpoint}: upserted {len(mapped)} rows for year {year} into {table}\")\n",
+    "    return len(mapped)\n",
+    "\n",
+    "\n",
+    "# Example driver: load several years for the selected endpoint\n",
+    "total = 0\n",
+    "for y in YEARS:\n",
+    "    total += load_core_for_year(ENDPOINT, y)\n",
+    "print(\"TOTAL rows processed:\", total)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18fc3165-79f5-4bde-b79b-9c20d0b620f9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
etl/core_io.py
ensure_core_table(endpoint): creates ipeds_core.{endpoint} with PK (unitid, year) and indexes on (year) and (state_abbr).

load_core_for_year(endpoint, year): flattens JSON from ipeds_raw.{endpoint}_raw, maps rows, and UPSERTs into core (idempotent).

etl/mappers/directory.py
Typed mapper for Directory records: converts -1/-2/-3 and blanks → NULL, coerces ints/floats/strings, and handles common key synonyms.

etl/registry.py
Endpoint registry for Directory with API path, full column schema, PK, and mapper hook.

Notebook: notebooks/20_load_core_directory.ipynb
Example end-to-end load (raw → core) with verification queries.